### PR TITLE
feat: add support for hugging face API tokens

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# HuggingFace API token
+HF_TOKEN=

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ flagged/
 
 # Local agent metadata
 .serena/
+
+# Environment variables
+.env

--- a/app.py
+++ b/app.py
@@ -10,7 +10,13 @@ FLUX.2-klein also supports image-to-image editing!
 """
 
 import os
+
 os.environ["PYTORCH_MPS_FAST_MATH"] = "1"
+
+from dotenv import load_dotenv
+load_dotenv()
+
+HF_TOKEN = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
 
 import torch
 import gradio as gr
@@ -170,6 +176,7 @@ def load_flux2_klein_pipeline(device="mps"):
         text_encoder=None,
         tokenizer=None,
         torch_dtype=torch.bfloat16,
+        token=HF_TOKEN,
     )
     print_memory("After VAE/scheduler download")
     
@@ -206,6 +213,7 @@ def load_flux2_klein_sdnq_pipeline(device="mps"):
         "black-forest-labs/FLUX.2-klein-4B",
         subfolder="tokenizer",
         use_fast=False,
+        token=HF_TOKEN,
     )
     
     pipe = Flux2KleinPipeline.from_pretrained(
@@ -244,6 +252,7 @@ def load_flux2_klein_9b_sdnq_pipeline(device="mps"):
         "black-forest-labs/FLUX.2-klein-9B",
         subfolder="tokenizer",
         use_fast=False,
+        token=HF_TOKEN,
     )
     
     pipe = Flux2KleinPipeline.from_pretrained(

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ pillow
 peft>=0.17.0
 scipy
 optimum-quanto>=0.2.7
+python-dotenv


### PR DESCRIPTION
For FLUX models, you have to request access to their repo, so you'll need to use access tokens to download the models.

This pull request introduces support for using a HuggingFace API token for model and tokenizer downloads, improving security and compatibility with private or rate-limited models. The token can now be set via environment variables and is loaded automatically at runtime.

**Environment variable and API token integration:**

* Added `HF_TOKEN` to `.env.example` to document the required HuggingFace API token environment variable.
* Updated `app.py` to load environment variables using `python-dotenv`, and set `HF_TOKEN` from either `HF_TOKEN` or `HUGGING_FACE_HUB_TOKEN` environment variables.

**Pipeline authentication updates:**

* Passed the `HF_TOKEN` to all `from_pretrained` and `AutoTokenizer.from_pretrained` calls in the model loading functions (`load_flux2_klein_pipeline`, `load_flux2_klein_sdnq_pipeline`, and `load_flux2_klein_9b_sdnq_pipeline`) to enable authenticated downloads. [[1]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R166) [[2]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R203) [[3]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R242)